### PR TITLE
Sailthru Demo Driver

### DIFF
--- a/app/Channels/SailthruChannel.php
+++ b/app/Channels/SailthruChannel.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Channels;
+
+use Illuminate\Notifications\Notification;
+
+class SailthruChannel
+{
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     */
+    public function send($user, Notification $notification)
+    {
+        $sailThruNotification = $notification->toSailthru($user);
+
+        $apiKey = '###';
+        $apiSecret = '###';
+        $sailthruClient = new \Sailthru_Client($apiKey, $apiSecret);
+
+        try {
+            $response = $sailthruClient->send(
+                $sailThruNotification->sailThruTemplate,
+                $user->email,
+                $sailThruNotification->sailThruParameters
+            );
+            if ( !isset($response['error']) ) {
+                // everything OK
+                return True;
+                // do something here
+            } else {
+                // handle API error
+                dd('Send Failed on API eror. ');
+            }
+        } catch (\Sailthru_Client_Exception $e) {
+
+            // deal with exceptions
+            dd(['Send Failed. ', $e->getMessage()]);
+        }
+
+        // Send notification to the $notifiable instance...
+    }
+}

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Notifications\WelcomeEmailNotification;
 use App\User;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Foundation\Auth\RegistersUsers;
 
@@ -68,4 +70,18 @@ class RegisterController extends Controller
             'password' => bcrypt($data['password']),
         ]);
     }
+
+
+    /**
+     * The user has been registered.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $user
+     * @return mixed
+     */
+    protected function registered(Request $request, User $user)
+    {
+        $user->notify(new WelcomeEmailNotification());
+    }
+
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,6 +6,7 @@ use App\Notifications\WelcomeEmailNotification;
 use App\User;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Foundation\Auth\RegistersUsers;
 
@@ -81,6 +82,7 @@ class RegisterController extends Controller
      */
     protected function registered(Request $request, User $user)
     {
+        Log::debug('In RegisterController registered Method');
         $user->notify(new WelcomeEmailNotification());
     }
 

--- a/app/Notifications/WelcomeEmailNotification.php
+++ b/app/Notifications/WelcomeEmailNotification.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Channels\SailthruChannel;
+use App\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class WelcomeEmailNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * @var string
+     */
+    public $sailThruTemplate = '';
+
+    /**
+     * @var array
+     */
+    public $sailThruParameters = [];
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return [
+            'mail',
+            SailthruChannel::class
+        ];
+    }
+
+    /**
+     * @param User $user
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail(User $user)
+    {
+        return (new MailMessage)
+                    ->subject("Hi {$user->name}, ")
+                    ->line('Thanks for signing up to ' . config('app.name'))
+                    ->line('Your account is ready, please login using the link below.')
+                    ->action('Login', route('login'))
+                    ->line('Thank you for using our application!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+
+
+    public function toSailthru(User $user)
+    {
+        $this->sailThruTemplate = 'account activation employer';
+        $this->sailThruParameters = [
+            'account_activation_link' => 'http://www.brightermonday.com',
+            'first_name' => $user->name,
+            'alert_link' => 'http://www.brightermonday.com',
+            'company_name' => 'Dylan Test Company',
+            'employer_title' => 'Dylan Test Employer',
+            'employer_name' => 'Dylan Test Employer'
+        ];
+
+        return $this;
+    }
+}

--- a/app/Notifications/WelcomeEmailNotification.php
+++ b/app/Notifications/WelcomeEmailNotification.php
@@ -8,8 +8,9 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Log;
 
-class WelcomeEmailNotification extends Notification
+class WelcomeEmailNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -30,6 +31,7 @@ class WelcomeEmailNotification extends Notification
      */
     public function __construct()
     {
+        Log::debug('In WelcomeEmailNotification Construct');
     }
 
     /**
@@ -40,6 +42,7 @@ class WelcomeEmailNotification extends Notification
      */
     public function via($notifiable)
     {
+        Log::debug('In WelcomeEmailNotification Via Method');
         return [
             'mail',
             SailthruChannel::class
@@ -52,6 +55,7 @@ class WelcomeEmailNotification extends Notification
      */
     public function toMail(User $user)
     {
+        Log::debug('In WelcomeEmailNotification toMail Method');
         return (new MailMessage)
                     ->subject("Hi {$user->name}, ")
                     ->line('Thanks for signing up to ' . config('app.name'))
@@ -76,6 +80,7 @@ class WelcomeEmailNotification extends Notification
 
     public function toSailthru(User $user)
     {
+        Log::debug('In WelcomeEmailNotification toSailthru Method');
         $this->sailThruTemplate = 'account activation employer';
         $this->sailThruParameters = [
             'account_activation_link' => 'http://www.brightermonday.com',

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "type": "project",
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.3.*"
+        "laravel/framework": "5.3.*",
+        "sailthru/sailthru-php5-client": "^1.2"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/config/app.php
+++ b/config/app.php
@@ -12,7 +12,7 @@ return [
     | any other location as required by the application or its packages.
     */
 
-    'name' => 'Laravel',
+    'name' => 'Sailthru Alternative Implementation',
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2017_06_28_080229_create_jobs_table.php
+++ b/database/migrations/2017_06_28_080229_create_jobs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue');
+            $table->longText('payload');
+            $table->tinyInteger('attempts')->unsigned();
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+            $table->index(['queue', 'reserved_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}


### PR DESCRIPTION
#### Sailthru on 5.3 by Example

This is an example of a basic implementation of Sailthru using Laravel notificatons. This is working, please see screenshots in PR. I've started with a clean install of Laravel 5.3 to illustrate how easy it is to get going. After generating the standard Laravel Auth scaffold I added 1 new notification class called "WelcomeEmailNotification"
. This gets triggered after user registration. In practice, you'd implement one class for each type of notification in the app (ProfileReminderNotification, NewsletterWelcomeNotificaiton etc etc). 

#### Getting Started
* Clone Repo
* Checkout the Sailthru branch (I kept the changes in branch to keep track of easier)
* Composer install, setup your ENV variables / DB / Mail Settings
* Insert your `$apiKey` and `$apiSecret` in the `SailthruChannel.php` (or pull from environment variable/config)
* Register a new user. The `WelcomeEmailNotification` will fire with two notifications. One via normal mail and one via the SailtruChannel


#### Benefits over current implementation

* Lightweight and Laravel friendly. Easy to understand and debug. 

* No need to swap out mail drivers: Sailthru notifications are not treated as emails so they don't interfere with our 
current mail drivers. That makes it a non breaking change to normal mails. 

* Define the Email and Sailthru Messages on the same class. This makes it easier to see what is happening. No need for configs to store various templates / overrides. 

* Run in Parallel. We can run in parallel, or do dynamic switching on the fly between Sailthru and Mail. Making it easier to "warm" the IP / Account. Switching between channels is as easy as modifying the `via()` method on the notification to either go by Mail, Sailthru or both. This can easily be done by a simple global(`config('sailthru.enabled')` type of config, or a more specific one per domain / template / anything else. Switching to a different channel is implemented by design, so it's not complicated.  

* Easy to send Admin mails via mail and other mails via Sailthru.

* Email templates using the mail method are beautifully styled already and super easy to implement / customize / change. 

* 100% fallback. If sailthru goes down, we switch our config off and start sending by normal mail. This *should* be  the case with our current implementation too, but notifications would make it easier to maintain the two channels  together.
 

* Notifications are amazing to test with the Notifications fake. We can use the Notifications fake to test the flow of our our app, and only need to use Mailthief / Mailtrap / Sailthru Fake to test each notification at most, once. Possibly, Developers could do super fast testing while developing with no need to test the external service (Mailthief / Sailthru Test fake).  The last leg to the external service can be run on builds only and can possibly be run in parallel with the rest of  the tests to speed up feedback.  
 
 * Extend past Mail / Sailthru: We can define instant Slack notifications, Push Notifications to our Web Apps, SMS to  phones etc all super easily without having to re-write how / when a notification is triggered. Many major  notifications channels are already supported out of the box like Slack and Push Notification services. 
 
 
#### To Do
*  I did this in just under an hour, it obviously needs more refinement to implement the Client better by a facade / 
 service provider. But that's not too complex if we don't have to hack with our mail driver. 
* Guest users would need a GuestUser class that uses the `notifiable` trait. This class would need to implement the minimum requirements for Sailthru (i.e. Store a Name, Email, etc). We could also make Advertisers Notifiable to send a notification to an Advertiser (i.e. Not to a user - following different rules. ).  
* I've ignored the rest of the Sailthru "features" like Mailing list management.
* Notification `toSailthru()` currently returns an instance of itself. In practice, we'd probably have a sperate  `SailthruNotify` type of  Class which can encapsulate the templat name and variables better. 